### PR TITLE
add default content-type header and statusCode

### DIFF
--- a/tinymux/lib/sendResponse.js
+++ b/tinymux/lib/sendResponse.js
@@ -1,4 +1,6 @@
 function sendResponse(response, responseWriter) {
+  responseWriter.setHeader('Content-Type', 'application/json');
+
   if (response.headers) {
     for (const key in response.headers) {
       if (response.headers.hasOwnProperty(key)) {
@@ -8,7 +10,7 @@ function sendResponse(response, responseWriter) {
     }
   }
 
-  Object.assign(responseWriter, { statusCode: response.statusCode });
+  Object.assign(responseWriter, { statusCode: response.statusCode || 200 });
   responseWriter.end(JSON.stringify(response.body));
 }
 


### PR DESCRIPTION
adds default values to the response object.
you are no longer required to specify the `content-type` header or the `statusCode`, which default to `application/json` and `200` respectively.