### PR TITLE
Improve route registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ s.handle('/v1/users', (req) => {
       message: 'Hello, World!',
     },
   }
-}, ['POST'])
+}, 'POST')
 
 s.start()
 ```
@@ -46,15 +46,19 @@ s.registerMiddleware('(.*)', (req) => console.log(new Date().toISOString(), req.
 s.registerMiddleware('(.*)', (req) => ({
   headers: {
     'Access-Control-Allow-Origin': '*',
-  }
+  },
 }))
 ```
 
 ## Handlers
 
+`s.handle(path: string, callback: (req: Request) => Response, method?: string)`
+
+The HTTP method is optional and defaults to `GET`.
+
 ### Built-in handlers
 
-tinymux comes with two built-in handlers. These can be overwritten if you want them to do something else.
+`tinymux` comes with two built-in handlers. These can be overwritten if you want them to do something else.
 
 ```js
 s.notFoundHandler()
@@ -87,7 +91,23 @@ s.handle('/users', async (req) => {
       },
     }
   }
-}, ['POST'])
+}, 'POST')
+
+s.handle('/users', async () => {
+  try {
+    const users = await db.getAllUsers()
+    return {
+      body: users,
+    }
+  } catch (err) {
+    return {
+      statusCode: err.statusCode || 500,
+      body: {
+        error: http.STATUS_CODES[err.statusCode || 500],
+      }.
+    }
+  }
+})
 
 s.handle('/users/:id', async (req) => {
   const { id } = req.vars
@@ -102,5 +122,5 @@ s.handle('/users/:id', async (req) => {
       },
     }
   }
-}, ['GET'])
+})
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymux",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymux",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymux",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymux",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Super lean REST API framework",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymux",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Super lean REST API framework",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymux",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Super lean REST API framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
breaking change: http method is now a string, instead of an array of strings.
new: support handler registration with same path, but different methods.
new: catch duplicate handlers (same path and http method)﻿
